### PR TITLE
Add structured exit codes, argument validation, and REST call guards

### DIFF
--- a/Python/spa_config.py
+++ b/Python/spa_config.py
@@ -44,7 +44,7 @@ SPA_NUM = -1
 SPA_IP = ""
 if len(sys.argv) == 6:
     if not is_integer(sys.argv[4]):
-        print(f"*** invalid spaNum argument: {sys.argv[4]}", file=sys.stderr)
+        print(f"*** invalid spaNum argument (not an integer): {sys.argv[4]}", file=sys.stderr)
         sys.exit(ExitCode.INVALID_ARGUMENTS)
     SPA_NUM = int(sys.argv[4])
     print(f"Number of ioBroker device: {SPA_NUM}")

--- a/Python/spa_config.py
+++ b/Python/spa_config.py
@@ -3,16 +3,35 @@ import asyncio
 import logging
 import requests
 import urllib
+from enum import IntEnum
 from geckolib import GeckoAsyncSpaMan, GeckoSpaEvent  # type: ignore
 
-VERSION = "0.3.3"
+class ExitCode(IntEnum):
+    SUCCESS = 0
+    INVALID_ARGUMENTS = 1
+    NO_SPAS_FOUND = 2
+    IOBROKER_REQUEST_EXCEPTION = 3
+    IOBROKER_HTTP_ERROR = 4
+    IOBROKER_INVALID_JSON = 5
+    IOBROKER_RESPONSE_ERROR = 6
+
+
+VERSION = "0.3.5"
 print(f"{sys.argv[0]} Version: {VERSION}")
 
 # Anzahl Argumente prüfen
 if len(sys.argv) != 4 and len(sys.argv) != 6:
     print("*** Wrong number of script arguments.", file=sys.stderr)
     print(f"*** call example: {sys.argv[0]} clientId ioBrSimpleRestApiUrl dpBasePath <<spaNum spaIP>>", file=sys.stderr)
-    sys.exit(1)
+    sys.exit(ExitCode.INVALID_ARGUMENTS)
+
+
+def is_integer(value: str) -> bool:
+    try:
+        int(value)
+        return True
+    except ValueError:
+        return False
 
 print("total arguments passed:", len(sys.argv))
 CLIENT_ID = sys.argv[1]
@@ -24,6 +43,9 @@ print(f"Base path to datapoints: {IOB_DP_BASE_PATH}")
 SPA_NUM = -1
 SPA_IP = ""
 if len(sys.argv) == 6:
+    if not is_integer(sys.argv[4]):
+        print(f"*** invalid spaNum argument: {sys.argv[4]}", file=sys.stderr)
+        sys.exit(ExitCode.INVALID_ARGUMENTS)
     SPA_NUM = int(sys.argv[4])
     print(f"Number of ioBroker device: {SPA_NUM}")
     SPA_IP = sys.argv[5]
@@ -37,7 +59,7 @@ class SampleSpaMan(GeckoAsyncSpaMan):
 
 
 async def main() -> int:
-    nReturnCode = 0
+    nReturnCode = ExitCode.SUCCESS
     spa_args = {}
         
     if SPA_NUM >= 0:
@@ -51,7 +73,7 @@ async def main() -> int:
 
         if len(spaman.spa_descriptors) == 0:
             print("there were no spas found on your network.", file=sys.stderr)
-            nReturnCode = 2
+            nReturnCode = ExitCode.NO_SPAS_FOUND
             return nReturnCode
 
         # get all spa names
@@ -171,13 +193,13 @@ async def main() -> int:
             except Exception as e:
                 print(e, file=sys.stderr)
                 print("an error occured on sending an http request to ioBroker Rest API, no data was sent, check url", file=sys.stderr)
-                nReturnCode = 3
+                nReturnCode = ExitCode.IOBROKER_REQUEST_EXCEPTION
             else:
                 if oResponse.status_code != 200:
                     print(f"http response code: {oResponse.status_code}", file=sys.stderr)
                     print("respose text:", file=sys.stderr)
                     print(oResponse.text, file=sys.stderr)
-                    nReturnCode = 4
+                    nReturnCode = ExitCode.IOBROKER_HTTP_ERROR
                 else:
                     print(f"http response code: {oResponse.status_code}")
                     try:
@@ -185,12 +207,12 @@ async def main() -> int:
                     except ValueError:
                         print("response is not valid JSON:", file=sys.stderr)
                         print(oResponse.text, file=sys.stderr)
-                        nReturnCode = 5
+                        nReturnCode = ExitCode.IOBROKER_INVALID_JSON
                     else:
                         for entry in oResponseJson:
                             if isinstance(entry, dict) and "error" in entry:
                                 print(entry["error"], file=sys.stderr)
-                                nReturnCode = 6
+                                nReturnCode = ExitCode.IOBROKER_RESPONSE_ERROR
             
             await asyncio.sleep(1)
 

--- a/Python/spa_setTargetTemp.py
+++ b/Python/spa_setTargetTemp.py
@@ -3,17 +3,29 @@ import asyncio
 import logging
 import requests
 import signal
+from enum import IntEnum
 
 from geckolib import GeckoAsyncSpaMan, GeckoSpaEvent  # type: ignore
 
-VERSION = "0.3.1"
+class ExitCode(IntEnum):
+    SUCCESS = 0
+    INVALID_ARGUMENTS = 1
+    NO_WATER_HEATER = 2
+    TARGET_TEMP_BELOW_MIN = 3
+    TARGET_TEMP_ABOVE_MAX = 4
+    IOBROKER_HTTP_ERROR = 5
+    IOBROKER_INVALID_JSON = 6
+    IOBROKER_RESPONSE_ERROR = 7
+
+
+VERSION = "0.3.3"
 print(f"{sys.argv[0]} Version: {VERSION}")
 
 # Anzahl Argumente prüfen
 if len(sys.argv) != 7:
     print("*** Wrong number of script arguments.", file=sys.stderr)
     print("*** call example: {sys.argv[0]} clientId restApiUrl spaId spaIP targetTemp targetTempDatapoint", file=sys.stderr)
-    sys.exit(1)
+    sys.exit(ExitCode.INVALID_ARGUMENTS)
 
 def is_float(element: any) -> bool:
     #If you expect None to be passed:
@@ -37,7 +49,7 @@ print(f"Connecting to spa ip {SPA_IP}")
 TARGET_TEMP = sys.argv[5]
 if (not is_float(TARGET_TEMP)):
     print(f"error: argument {TARGET_TEMP} is not a float")
-    sys.exit(1)
+    sys.exit(ExitCode.INVALID_ARGUMENTS)
 print(f"New target temp: {TARGET_TEMP}")
 IOBR_TARGET_TEMP_DP = sys.argv[6]
 print(f"Got datapoint to update: {IOBR_TARGET_TEMP_DP}")
@@ -56,7 +68,7 @@ class SampleSpaMan(GeckoAsyncSpaMan):
         pass
 
 async def main() -> int:
-    nReturnCode = 0
+    nReturnCode = ExitCode.SUCCESS
     set_run_timeout(30)
 
     async with SampleSpaMan(CLIENT_ID, spa_identifier=SPA_ID, spa_address=SPA_IP) as spaman:
@@ -75,7 +87,7 @@ async def main() -> int:
                 print(f"*** water heater available")
             else:
                 print(f"error: no water heater available returned from geckolib", file=sys.stderr)
-                nReturnCode = 2
+                nReturnCode = ExitCode.NO_WATER_HEATER
                 return nReturnCode
             
             print(f"*** current target temp: {spaman.facade.water_heater.target_temperature}")
@@ -83,11 +95,11 @@ async def main() -> int:
             # check that new target temp is in temp range
             if float(TARGET_TEMP) < float(spaman.facade.water_heater.min_temp):
                 print(f"error: new target temp ({TARGET_TEMP}) below minimum value ({spaman.facade.water_heater.min_temp})", file=sys.stderr)
-                nReturnCode = 3
+                nReturnCode = ExitCode.TARGET_TEMP_BELOW_MIN
                 return nReturnCode
             if float(TARGET_TEMP) > float(spaman.facade.water_heater.max_temp):
                 print(f"error: new target temp ({TARGET_TEMP}) above maximum value ({spaman.facade.water_heater.max_temp})", file=sys.stderr)
-                nReturnCode = 4
+                nReturnCode = ExitCode.TARGET_TEMP_ABOVE_MAX
                 return nReturnCode
 
             if float(spaman.facade.water_heater.target_temperature) != float(TARGET_TEMP):
@@ -110,6 +122,11 @@ async def main() -> int:
             print(f"*** cannot establish connection to spa controller, spa_state: {spaman.spa_state}", file=sys.stderr)
         
         sJson2Send = sJson2Send[:len(sJson2Send)-2] + ""
+        if not sJson2Send.strip():
+            print("*** no payload generated for setBulk, skipping REST call")
+            print("*** end")
+            return ExitCode.SUCCESS
+
         #print(sJson2Send)
         try:
             oResponse = requests.post("{}/setBulk".format(IOBRURL), data = sJson2Send)
@@ -121,7 +138,7 @@ async def main() -> int:
                 print(f"http response code: {oResponse.status_code}", file=sys.stderr)
                 print("respose text:", file=sys.stderr)
                 print(oResponse.text, file=sys.stderr)
-                nReturnCode = 5
+                nReturnCode = ExitCode.IOBROKER_HTTP_ERROR
             else:
                 print(f"http response code: {oResponse.status_code}")
                 try:
@@ -129,12 +146,12 @@ async def main() -> int:
                 except ValueError:
                     print("response is not valid JSON:", file=sys.stderr)
                     print(oResponse.text, file=sys.stderr)
-                    nReturnCode = 6
+                    nReturnCode = ExitCode.IOBROKER_INVALID_JSON
                 else:
                     for entry in oResponseJson:
                         if isinstance(entry, dict) and "error" in entry:
                             print(entry["error"], file=sys.stderr)
-                            nReturnCode = 7
+                            nReturnCode = ExitCode.IOBROKER_RESPONSE_ERROR
         
         # ende
         print("*** end")

--- a/Python/spa_setTargetTemp.py
+++ b/Python/spa_setTargetTemp.py
@@ -16,6 +16,7 @@ class ExitCode(IntEnum):
     IOBROKER_HTTP_ERROR = 5
     IOBROKER_INVALID_JSON = 6
     IOBROKER_RESPONSE_ERROR = 7
+    IOBROKER_REQUEST_EXCEPTION = 8
 
 
 VERSION = "0.3.3"
@@ -110,7 +111,7 @@ async def main() -> int:
                 print(f"*** new target temp is identical to current, nothing to do")
             
             # sending state updates to ioBroker
-            sJson2Send = sJson2Send + "{}={}".format(IOBR_TARGET_TEMP_DP, str(spaman.facade.water_heater.target_temperature)) + "&ack=true& "
+            sJson2Send = sJson2Send + "{}={}".format(IOBR_TARGET_TEMP_DP, str(spaman.facade.water_heater.target_temperature)) + "&"
             
             # kurz warten (löst das Problem mit den längeren Wartezeiten)
             await asyncio.sleep(1)
@@ -121,18 +122,20 @@ async def main() -> int:
         else:
             print(f"*** cannot establish connection to spa controller, spa_state: {spaman.spa_state}", file=sys.stderr)
         
-        sJson2Send = sJson2Send[:len(sJson2Send)-2] + ""
-        if not sJson2Send.strip():
-            print("*** no payload generated for setBulk, skipping REST call")
+        if not sJson2Send:
+            print("*** no ioBroker updates to send")
             print("*** end")
-            return ExitCode.SUCCESS
+            return nReturnCode
 
-        #print(sJson2Send)
+        if len(sJson2Send) > 0:
+            sJson2Send = sJson2Send + "ack=true"
+
         try:
             oResponse = requests.post("{}/setBulk".format(IOBRURL), data = sJson2Send)
         except Exception as e:
             print(e)
             print("an error occured on sending an http request to ioBroker Rest API, no data was sent, check url", file=sys.stderr)
+            nReturnCode = ExitCode.IOBROKER_REQUEST_EXCEPTION
         else:
             if oResponse.status_code != 200:
                 print(f"http response code: {oResponse.status_code}", file=sys.stderr)

--- a/Python/spa_setWatercareMode.py
+++ b/Python/spa_setWatercareMode.py
@@ -4,6 +4,7 @@ import logging
 import requests
 import signal
 import urllib.parse
+from enum import IntEnum
 
 dictEn2De = {'Away From Home': 'Abwesend',
           'Standard': 'Standard', 
@@ -14,14 +15,22 @@ dictEn2De = {'Away From Home': 'Abwesend',
 
 from geckolib import GeckoAsyncSpaMan, GeckoSpaEvent  # type: ignore
 
-VERSION = "0.3.1"
+class ExitCode(IntEnum):
+    SUCCESS = 0
+    INVALID_ARGUMENTS = 1
+    IOBROKER_HTTP_ERROR = 2
+    IOBROKER_INVALID_JSON = 3
+    IOBROKER_RESPONSE_ERROR = 4
+
+
+VERSION = "0.3.2"
 print(f"{sys.argv[0]} Version: {VERSION}")
 
 # Anzahl Argumente prüfen
 if len(sys.argv) != 7:
     print("*** Wrong number of script arguments.", file=sys.stderr)
     print("*** call example: {sys.argv[0]} clientId restApiUrl spaId spaIP waterCareModeIdx devicePath", file=sys.stderr)
-    sys.exit(1)
+    sys.exit(ExitCode.INVALID_ARGUMENTS)
 
 def is_integer(n):
     try:
@@ -43,11 +52,11 @@ print(f"Connecting to spa id {SPA_IP}")
 NEW_WATERCAREMODE_IDX = sys.argv[5]
 if (not is_integer(NEW_WATERCAREMODE_IDX)):
     print(f"error: value {NEW_WATERCAREMODE_IDX} of argument 4 is not an int", file=sys.stderr)
-    sys.exit(1)
+    sys.exit(ExitCode.INVALID_ARGUMENTS)
 NEW_WATERCAREMODE_IDX = int(NEW_WATERCAREMODE_IDX)
-if (NEW_WATERCAREMODE_IDX < 0 and NEW_WATERCAREMODE_IDX > 4):
+if (NEW_WATERCAREMODE_IDX < 0 or NEW_WATERCAREMODE_IDX > 4):
     print(f"error: value {NEW_WATERCAREMODE_IDX} is out of allowed range", file=sys.stderr)
-    sys.exit(1)
+    sys.exit(ExitCode.INVALID_ARGUMENTS)
 print(f"New watercare mode index: {NEW_WATERCAREMODE_IDX}")
 IOBR_DEVICE_PATH = sys.argv[6]
 print(f"Got device path to update: {IOBR_DEVICE_PATH}")
@@ -66,7 +75,7 @@ class SampleSpaMan(GeckoAsyncSpaMan):
         pass
 
 async def main() -> int:
-    nReturnCode = 0
+    nReturnCode = ExitCode.SUCCESS
     set_run_timeout(30)
 
     async with SampleSpaMan(CLIENT_ID, spa_identifier=SPA_ID, spa_address=SPA_IP) as spaman:
@@ -110,6 +119,11 @@ async def main() -> int:
             sJson2Send = sJson2Send + "{}.Sensoren.Status.State={}".format(IOBR_DEVICE_PATH, urllib.parse.quote("Connect failed")) + "&ack=true& "
         
         sJson2Send = sJson2Send[:len(sJson2Send)-2] + ""
+        if not sJson2Send.strip():
+            print("*** no payload generated for setBulk, skipping REST call")
+            print("*** end")
+            return ExitCode.SUCCESS
+
         print(sJson2Send)
         try:
             oResponse = requests.post("{}/setBulk".format(IOBRURL), data = sJson2Send)
@@ -121,7 +135,7 @@ async def main() -> int:
                 print(f"http response code: {oResponse.status_code}", file=sys.stderr)
                 print("respose text:", file=sys.stderr)
                 print(oResponse.text, file=sys.stderr)
-                nReturnCode = 2
+                nReturnCode = ExitCode.IOBROKER_HTTP_ERROR
             else:
                 print(f"http response code: {oResponse.status_code}")
                 try:
@@ -129,12 +143,12 @@ async def main() -> int:
                 except ValueError:
                     print("response is not valid JSON:", file=sys.stderr)
                     print(oResponse.text, file=sys.stderr)
-                    nReturnCode = 3
+                    nReturnCode = ExitCode.IOBROKER_INVALID_JSON
                 else:
                     for entry in oResponseJson:
                         if isinstance(entry, dict) and "error" in entry:
                             print(entry["error"], file=sys.stderr)
-                            nReturnCode = 4
+                            nReturnCode = ExitCode.IOBROKER_RESPONSE_ERROR
 
         # ende
         print("*** end")

--- a/Python/spa_setWatercareMode.py
+++ b/Python/spa_setWatercareMode.py
@@ -21,6 +21,7 @@ class ExitCode(IntEnum):
     IOBROKER_HTTP_ERROR = 2
     IOBROKER_INVALID_JSON = 3
     IOBROKER_RESPONSE_ERROR = 4
+    IOBROKER_REQUEST_EXCEPTION = 5
 
 
 VERSION = "0.3.2"
@@ -98,7 +99,7 @@ async def main() -> int:
             if currentWatercareMode == NEW_WATERCAREMODE_IDX:
                 print(f"*** nothing to do, old and new watercare mode are equal")
                 # sending state updates to ioBroker
-                sJson2Send = sJson2Send + "{}.WasserpflegeSwitch={}".format(IOBR_DEVICE_PATH, currentWatercareMode) + "&ack=true& "
+                sJson2Send = sJson2Send + "{}.WasserpflegeSwitch={}".format(IOBR_DEVICE_PATH, currentWatercareMode) + "&"
             else:
                 print(f"*** changing watercare mode from \"{spaman.facade.water_care.modes[currentWatercareMode]}\" to: \"{spaman.facade.water_care.modes[NEW_WATERCAREMODE_IDX]}\"")
 
@@ -106,7 +107,7 @@ async def main() -> int:
                 await spaman.facade.water_care.async_set_mode(spaman.facade.water_care.modes[NEW_WATERCAREMODE_IDX])
             
                 # sending state updates to ioBroker
-                sJson2Send = sJson2Send + "{}.WasserpflegeSwitch={}".format(IOBR_DEVICE_PATH, NEW_WATERCAREMODE_IDX) + "&ack=true& "
+                sJson2Send = sJson2Send + "{}.WasserpflegeSwitch={}".format(IOBR_DEVICE_PATH, NEW_WATERCAREMODE_IDX) + "&"
             
             # kurz warten (löst das Problem mit den längeren Wartezeiten)
             await asyncio.sleep(1)
@@ -116,13 +117,15 @@ async def main() -> int:
             print("connection closed/reset")
         else:
             print(f"*** cannot establish connection to spa controller, spa_state: {spaman.spa_state}", file=sys.stderr)
-            sJson2Send = sJson2Send + "{}.Sensoren.Status.State={}".format(IOBR_DEVICE_PATH, urllib.parse.quote("Connect failed")) + "&ack=true& "
+            sJson2Send = sJson2Send + "{}.Sensoren.Status.State={}".format(IOBR_DEVICE_PATH, urllib.parse.quote("Connect failed")) + "&"
         
-        sJson2Send = sJson2Send[:len(sJson2Send)-2] + ""
-        if not sJson2Send.strip():
-            print("*** no payload generated for setBulk, skipping REST call")
+        if not sJson2Send:
+            print("*** no ioBroker updates to send")
             print("*** end")
-            return ExitCode.SUCCESS
+            return nReturnCode
+
+        if len(sJson2Send) > 0:
+            sJson2Send = sJson2Send + "ack=true"
 
         print(sJson2Send)
         try:
@@ -130,6 +133,7 @@ async def main() -> int:
         except Exception as e:
             print(e)
             print("an error occured on sending an http request to ioBroker Rest API, no data was sent, check url", file=sys.stderr)
+            nReturnCode = ExitCode.IOBROKER_REQUEST_EXCEPTION
         else:
             if oResponse.status_code != 200:
                 print(f"http response code: {oResponse.status_code}", file=sys.stderr)

--- a/Python/spa_switchPump.py
+++ b/Python/spa_switchPump.py
@@ -18,9 +18,10 @@ class ExitCode(IntEnum):
     INVALID_HTTP_RESPONSE = 6
     IOBROKER_API_ERROR = 7
     SPA_CONNECTION_FAILED = 8
+    IOBROKER_REQUEST_EXCEPTION = 9
 
 
-VERSION = "0.2.6"
+VERSION = "0.2.7"
 print(f"{sys.argv[0]} Version: {VERSION}")
 
 # Anzahl Argumente prüfen
@@ -158,7 +159,7 @@ async def main() -> ExitCode:
         except Exception as e:
             print(e)
             print("an error occured on sending an http request to ioBroker Rest API, no data was sent, check url", file=sys.stderr)
-            return_code = ExitCode.HTTP_ERROR
+            return_code = ExitCode.IOBROKER_REQUEST_EXCEPTION
         else:
             if oResponse.status_code != 200:
                 print(f"http response code: {oResponse.status_code}", file=sys.stderr)

--- a/Python/spa_toggleLight.py
+++ b/Python/spa_toggleLight.py
@@ -17,9 +17,10 @@ class ExitCode(IntEnum):
     INVALID_HTTP_RESPONSE = 5
     IOBROKER_API_ERROR = 6
     SPA_CONNECTION_FAILED = 7
+    IOBROKER_REQUEST_EXCEPTION = 8
 
 
-VERSION = "0.2.6"
+VERSION = "0.2.7"
 print(f"{sys.argv[0]} Version: {VERSION}")
 
 # Anzahl Argumente prüfen
@@ -127,7 +128,7 @@ async def main() -> ExitCode:
         except Exception as e:
             print(e)
             print("an error occured on sending an http request to ioBroker Rest API, no data was sent, check url", file=sys.stderr)
-            return_code = ExitCode.HTTP_ERROR
+            return_code = ExitCode.IOBROKER_REQUEST_EXCEPTION
         else:
             if oResponse.status_code != 200:
                 print(f"http response code: {oResponse.status_code}", file=sys.stderr)

--- a/Python/spa_updateBulk.py
+++ b/Python/spa_updateBulk.py
@@ -16,6 +16,7 @@ class ExitCode(IntEnum):
     IOBROKER_HTTP_ERROR = 2
     IOBROKER_INVALID_JSON = 3
     IOBROKER_RESPONSE_ERROR = 4
+    IOBROKER_REQUEST_EXCEPTION = 5
 
 
 VERSION = "0.3.3"
@@ -343,6 +344,11 @@ async def main() -> int:
                     print(f"*** cannot establish connection to spa controller, spa_state: {spaman.spa_state}", file=sys.stderr)
                     sData2Send = sData2Send + "{}.{}.Sensoren.Status.State={}".format(IOB_DP_BASE_PATH, nSpaNum, urllib.parse.quote("Connect failed")) + "&"
     
+    if not sData2Send:
+            print("*** no ioBroker updates to send")
+            print("*** end")
+            return nReturnCode
+    
     if len(sData2Send) > 0:
         sData2Send = sData2Send + "ack=true"
     
@@ -353,6 +359,7 @@ async def main() -> int:
         except Exception as e:
             print(e)
             print("an error occured on sending an http request to ioBroker Rest API, no data was sent, check url", file=sys.stderr)
+            nReturnCode = ExitCode.IOBROKER_REQUEST_EXCEPTION
         else:
             if oResponse.status_code != 200:
                 print(f"http response code: {oResponse.status_code}", file=sys.stderr)

--- a/Python/spa_updateBulk.py
+++ b/Python/spa_updateBulk.py
@@ -6,17 +6,26 @@ import logging
 import signal
 import json
 from typing import Any
+from enum import IntEnum
 
 from geckolib import GeckoAsyncSpaMan, GeckoSpaEvent  # type: ignore
 
-VERSION = "0.3.2"
+class ExitCode(IntEnum):
+    SUCCESS = 0
+    INVALID_ARGUMENTS = 1
+    IOBROKER_HTTP_ERROR = 2
+    IOBROKER_INVALID_JSON = 3
+    IOBROKER_RESPONSE_ERROR = 4
+
+
+VERSION = "0.3.3"
 print(f"{sys.argv[0]} Version: {VERSION}")
 
 # Anzahl Argumente prüfen
 if len(sys.argv) != 6:
     print("*** Wrong number of script arguments.", file=sys.stderr)
     print(f"*** call example: {sys.argv[0]} clientId ioBrSimpleRestApiUrl spaIds spaIPs dpBasePath", file=sys.stderr)
-    sys.exit(1)
+    sys.exit(ExitCode.INVALID_ARGUMENTS)
 
 print("total arguments passed:", len(sys.argv))
 CLIENT_ID = sys.argv[1]
@@ -152,7 +161,7 @@ def safe_float(value: Any, default: float = 0.0) -> float:
         return default
 
 async def main() -> int:
-    nReturnCode = 0
+    nReturnCode = ExitCode.SUCCESS
     sData2Send = ""
     set_run_timeout(90)
 
@@ -349,7 +358,7 @@ async def main() -> int:
                 print(f"http response code: {oResponse.status_code}", file=sys.stderr)
                 print("respose text:", file=sys.stderr)
                 print(oResponse.text, file=sys.stderr)
-                nReturnCode = 2
+                nReturnCode = ExitCode.IOBROKER_HTTP_ERROR
             else:
                 print(f"http response code: {oResponse.status_code}")
                 try:
@@ -357,12 +366,12 @@ async def main() -> int:
                 except ValueError:
                     print("response is not valid JSON:", file=sys.stderr)
                     print(oResponse.text, file=sys.stderr)
-                    nReturnCode = 3
+                    nReturnCode = ExitCode.IOBROKER_INVALID_JSON
                 else:
                     for entry in oResponseJson:
                         if isinstance(entry, dict) and "error" in entry:
                             print(entry["error"], file=sys.stderr)
-                            nReturnCode = 4
+                            nReturnCode = ExitCode.IOBROKER_RESPONSE_ERROR
     else:
         print("nothing to send")
     


### PR DESCRIPTION
### Motivation
- Provide structured, readable exit codes for scripts that interact with ioBroker and geckolib. 
- Harden CLI argument validation to prevent invalid input from causing runtime errors. 
- Avoid unnecessary REST `setBulk` calls when no payload is generated and correct a logic bug in watercare mode validation.

### Description
- Introduced an `ExitCode` `IntEnum` in `spa_config.py`, `spa_setTargetTemp.py`, `spa_setWatercareMode.py`, and `spa_updateBulk.py` and replaced numeric `sys.exit`/return values with the enum members and bumped `VERSION` strings. 
- Added input validation helpers (`is_integer`, reuse of `is_float`) and used them to validate CLI arguments, exiting with `ExitCode.INVALID_ARGUMENTS` on invalid inputs. 
- Guarded against empty payloads in `spa_setTargetTemp.py` and `spa_setWatercareMode.py` by skipping the `setBulk` REST call when no data is produced. 
- Fixed a logical range-check bug in `spa_setWatercareMode.py` (use `or` instead of `and`) and mapped HTTP/JSON/response errors to specific `ExitCode` members across scripts.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a48b58ae288328a939b6c027b4ace0)