### PR TITLE
Build safe shell commands and ensure scriptRunning reset on errors

### DIFF
--- a/JavaScript/LightToggle.js
+++ b/JavaScript/LightToggle.js
@@ -53,10 +53,23 @@ async function toggleLight(obj) {
     setState(dpBasePath + '.scriptRunning', {val: true, ack: true});
 
     // spa_toggleLight.py clientId spaId lightKey lightChannel
-    console.log('*** executing: ' + SPA_EXECUTEABLE + ' ' + pyScriptFolder + 'spa_toggleLight.py ' + clientId + " " + getRestApiUrl() + " " + spaId + " " + spaIP + " " + lightKey + " " + obj.channelId);
-    await execPythonAsync(SPA_EXECUTEABLE + ' ' + pyScriptFolder + 'spa_toggleLight.py ' + clientId + " " + getRestApiUrl() + " " + spaId + " " + spaIP + " " + lightKey + " " + obj.channelId);
+    const toggleLightCommand = buildShellCommand([
+        SPA_EXECUTEABLE,
+        pyScriptFolder + 'spa_toggleLight.py',
+        clientId,
+        getRestApiUrl(),
+        spaId,
+        spaIP,
+        lightKey,
+        obj.channelId
+    ]);
+    console.log('*** executing: ' + toggleLightCommand);
 
-    // signal that there is no longer a script is running
-    setState(dpBasePath + '.scriptRunning', {val: false, ack: true});
+    try {
+        await execPythonAsync(toggleLightCommand);
+    } finally {
+        // signal that there is no longer a script is running
+        setState(dpBasePath + '.scriptRunning', {val: false, ack: true});
+    }
     console.log("end");
 }

--- a/JavaScript/PumpSwitches.js
+++ b/JavaScript/PumpSwitches.js
@@ -54,10 +54,24 @@ async function switchPump(obj) {
     setState(dpBasePath + '.scriptRunning', {val: true, ack: true});
 
     // spa_switchPump.py clientId restApiUrl spaId pumpId newPumpState pumpChannel
-    console.log('*** executing: ' + SPA_EXECUTEABLE + ' ' + pyScriptFolder + 'spa_switchPump.py ' + clientId + " " + getRestApiUrl() + " " + spaId + " " + spaIP + " " + pumpId + " " + newState + " " + obj.channelId);
-    await execPythonAsync(SPA_EXECUTEABLE + ' ' + pyScriptFolder + 'spa_switchPump.py ' + clientId + " " + getRestApiUrl() + " " + spaId + " " + spaIP + " " + pumpId + " " + newState + " " + obj.channelId);
+    const switchPumpCommand = buildShellCommand([
+        SPA_EXECUTEABLE,
+        pyScriptFolder + 'spa_switchPump.py',
+        clientId,
+        getRestApiUrl(),
+        spaId,
+        spaIP,
+        pumpId,
+        newState,
+        obj.channelId
+    ]);
+    console.log('*** executing: ' + switchPumpCommand);
 
-    // signal that there is no longer a script is running
-    setState(dpBasePath + '.scriptRunning', {val: false, ack: true});
+    try {
+        await execPythonAsync(switchPumpCommand);
+    } finally {
+        // signal that there is no longer a script is running
+        setState(dpBasePath + '.scriptRunning', {val: false, ack: true});
+    }
     console.log("end");
 }

--- a/JavaScript/SpaUpdateConfig.js
+++ b/JavaScript/SpaUpdateConfig.js
@@ -51,53 +51,80 @@ async function updateSpaConfig() {
     // signal that a script is running
     setState(dpBasePath + '.scriptRunning', {val: true, ack: true});
 
-    var disabledControllerCnt = 0;
-    if (controllerDisabled) {
-        console.log("found at least one disabled controller, executing only selectivly configuration updates for enabled controllers, initial discovery not possible");
-        var controller2Check = [];
-        $('state[id=' + BASE_ADAPTER + "." + BASE_FOLDER + '*.IPAddresse]').each(function(id, i) {
-            var spaIP = "";
-            spaIP = getState(id).val;
-            if (spaIP != "") {
-                if (getState(id.replace(".IPAddresse", ".ControllerEnabled")).val == true) {
-                    controller2Check[i] = spaIP;
-                } else {
-                    controller2Check[i] = "";
-                    disabledControllerCnt++;
+    try {
+        var disabledControllerCnt = 0;
+        if (controllerDisabled) {
+            console.log("found at least one disabled controller, executing only selectivly configuration updates for enabled controllers, initial discovery not possible");
+            var controller2Check = [];
+            $('state[id=' + BASE_ADAPTER + "." + BASE_FOLDER + '*.IPAddresse]').each(function(id, i) {
+                var spaIP = "";
+                spaIP = getState(id).val;
+                if (spaIP != "") {
+                    if (getState(id.replace(".IPAddresse", ".ControllerEnabled")).val == true) {
+                        controller2Check[i] = spaIP;
+                    } else {
+                        controller2Check[i] = "";
+                        disabledControllerCnt++;
+                    }
+                }
+            });
+            for (let i = 0; i < controller2Check.length; i++) {
+                if (controller2Check[i] != "") {
+                    console.log("doing config update for: " + i + ", " + controller2Check[i]);
+                    // spa_config.py clientId restApiUrl dpBasePath index ipaddress
+                    const updateCommand = buildShellCommand([
+                        SPA_EXECUTEABLE,
+                        pyScriptFolder + 'spa_config.py',
+                        clientId,
+                        getRestApiUrl(),
+                        dpBasePath,
+                        i,
+                        controller2Check[i]
+                    ]);
+                    console.log('*** executing: ' + updateCommand);
+                    await execPythonAsync(updateCommand);
                 }
             }
-        });
-        for (let i = 0; i < controller2Check.length; i++) {
-            if (controller2Check[i] != "") {
-                console.log("doing config update for: " + i + ", " + controller2Check[i]);
-                // spa_config.py clientId restApiUrl dpBasePath index ipaddress
-                console.log('*** executing: ' + SPA_EXECUTEABLE + ' ' + pyScriptFolder + 'spa_config.py ' + clientId + " " + getRestApiUrl() + " " + dpBasePath + " " + i + " " + controller2Check[i]);
-                await execPythonAsync(SPA_EXECUTEABLE + ' ' + pyScriptFolder + 'spa_config.py ' + clientId + " " + getRestApiUrl() + " " + dpBasePath + " " + i + " " + controller2Check[i]);
-            }
-        }
-        if (controller2Check.length - disabledControllerCnt == 0) {
-            console.warn("no enabled controller found, check your configuration.");
-        }
-    } else {
-        console.log("no disabled controller, doing standard discovery")
-        // discover SpaController
-        if (discoverIPs != "") {
-            // by given IP
-            for (let i = 0; i < discoverIPs.length; i++) {
-                console.log("*** discovering IP: " + i + " => " + discoverIPs[i]);
-                // spa_config.py clientId restApiUrl dpBasePath spaNum spaIP
-                console.log('*** executing: ' + SPA_EXECUTEABLE + ' ' + pyScriptFolder + 'spa_config.py ' + clientId + " " + getRestApiUrl() + " " + dpBasePath + " " + i + " " + discoverIPs[i]);
-                await execPythonAsync(SPA_EXECUTEABLE + ' ' + pyScriptFolder + 'spa_config.py ' + clientId + " " + getRestApiUrl() + " " + dpBasePath + " " + i + " " + discoverIPs[i]);
+            if (controller2Check.length - disabledControllerCnt == 0) {
+                console.warn("no enabled controller found, check your configuration.");
             }
         } else {
-            // by broadcast 
-            // spa_config.py clientId restApiUrl dpBasePath
-            console.log('*** executing: ' + SPA_EXECUTEABLE + ' ' + pyScriptFolder + 'spa_config.py ' + clientId + " " + getRestApiUrl() + " " + dpBasePath);
-            await execPythonAsync(SPA_EXECUTEABLE + ' ' + pyScriptFolder + 'spa_config.py ' + clientId + " " + getRestApiUrl() + " " + dpBasePath);
+            console.log("no disabled controller, doing standard discovery")
+            // discover SpaController
+            if (discoverIPs != "") {
+                // by given IP
+                for (let i = 0; i < discoverIPs.length; i++) {
+                    console.log("*** discovering IP: " + i + " => " + discoverIPs[i]);
+                    // spa_config.py clientId restApiUrl dpBasePath spaNum spaIP
+                    const discoverCommand = buildShellCommand([
+                        SPA_EXECUTEABLE,
+                        pyScriptFolder + 'spa_config.py',
+                        clientId,
+                        getRestApiUrl(),
+                        dpBasePath,
+                        i,
+                        discoverIPs[i]
+                    ]);
+                    console.log('*** executing: ' + discoverCommand);
+                    await execPythonAsync(discoverCommand);
+                }
+            } else {
+                // by broadcast 
+                // spa_config.py clientId restApiUrl dpBasePath
+                const discoverCommand = buildShellCommand([
+                    SPA_EXECUTEABLE,
+                    pyScriptFolder + 'spa_config.py',
+                    clientId,
+                    getRestApiUrl(),
+                    dpBasePath
+                ]);
+                console.log('*** executing: ' + discoverCommand);
+                await execPythonAsync(discoverCommand);
+            }
         }
+    } finally {
+        // signal that there is no longer a script is running
+        setState(dpBasePath + '.scriptRunning', {val: false, ack: true});
     }
-
-    // signal that there is no longer a script is running
-    setState(dpBasePath + '.scriptRunning', {val: false, ack: true});
     console.log("end");
 }

--- a/JavaScript/SpaUpdateValues.js
+++ b/JavaScript/SpaUpdateValues.js
@@ -67,10 +67,22 @@ async function updateSpaValues() {
     setState(dpBasePath + '.scriptRunning', {val: true, ack: true});
 
     // spa_updateBulk.py clientId restApiUrl spaIdList dpBasePath
-    console.log('*** executing: ' + SPA_EXECUTEABLE + ' ' + pyScriptFolder + 'spa_updateBulk.py ' + clientId + " " + getRestApiUrl() + " " + spaIdList + " " + spaIPList + " " + dpBasePath);
-    await execPythonAsync(SPA_EXECUTEABLE + ' ' + pyScriptFolder + 'spa_updateBulk.py ' + clientId + " " + getRestApiUrl() + " " + spaIdList + " " + spaIPList + " " + dpBasePath);
+    const updateCommand = buildShellCommand([
+        SPA_EXECUTEABLE,
+        pyScriptFolder + 'spa_updateBulk.py',
+        clientId,
+        getRestApiUrl(),
+        spaIdList,
+        spaIPList,
+        dpBasePath
+    ]);
+    console.log('*** executing: ' + updateCommand);
 
-    // signal that there is no longer a script is running
-    setState(dpBasePath + '.scriptRunning', {val: false, ack: true});
+    try {
+        await execPythonAsync(updateCommand);
+    } finally {
+        // signal that there is no longer a script is running
+        setState(dpBasePath + '.scriptRunning', {val: false, ack: true});
+    }
     console.log("end");
 }

--- a/JavaScript/TargetTemp.js
+++ b/JavaScript/TargetTemp.js
@@ -49,10 +49,23 @@ async function setTargetTemp(obj) {
     setState(dpBasePath + '.scriptRunning', {val: true, ack: true});
 
     // spa_setTargetTemp.py clientId restApiUrl spaId targetTemp targetTempDatapoint
-    console.log('*** executing: ' + SPA_EXECUTEABLE + ' ' + pyScriptFolder + 'spa_setTargetTemp.py ' + clientId + " " + getRestApiUrl() + " " + spaId + " " + spaIP + " " + newState + " " + obj.id);
-    await execPythonAsync(SPA_EXECUTEABLE + ' ' + pyScriptFolder + 'spa_setTargetTemp.py ' + clientId + " " + getRestApiUrl() + " " + spaId + " " + spaIP + " " + newState + " " + obj.id);
+    const targetTempCommand = buildShellCommand([
+        SPA_EXECUTEABLE,
+        pyScriptFolder + 'spa_setTargetTemp.py',
+        clientId,
+        getRestApiUrl(),
+        spaId,
+        spaIP,
+        newState,
+        obj.id
+    ]);
+    console.log('*** executing: ' + targetTempCommand);
 
-    // signal that there is no longer a script is running
-    setState(dpBasePath + '.scriptRunning', {val: false, ack: true});
+    try {
+        await execPythonAsync(targetTempCommand);
+    } finally {
+        // signal that there is no longer a script is running
+        setState(dpBasePath + '.scriptRunning', {val: false, ack: true});
+    }
     console.log("end");
 }

--- a/JavaScript/WatercareMode.js
+++ b/JavaScript/WatercareMode.js
@@ -51,10 +51,23 @@ async function setWatercareMode(obj) {
     setState(dpBasePath + '.scriptRunning', {val: true, ack: true});
 
     // spa_toggleLight.py clientId restApiUrl spaId lightKey lightChannel
-    console.log('*** executing: ' + SPA_EXECUTEABLE + ' ' + pyScriptFolder + 'spa_setWatercareMode.py ' + clientId + " " + getRestApiUrl() + " " + spaId + " " + spaIP + " " + newWaterCareModeIdx + " " + getParent(obj.id, 1));
-    await execPythonAsync(SPA_EXECUTEABLE + ' ' + pyScriptFolder + 'spa_setWatercareMode.py ' + clientId + " " + getRestApiUrl() + " " + spaId + " " + spaIP + " " + newWaterCareModeIdx + " " + getParent(obj.id, 1));
+    const watercareModeCommand = buildShellCommand([
+        SPA_EXECUTEABLE,
+        pyScriptFolder + 'spa_setWatercareMode.py',
+        clientId,
+        getRestApiUrl(),
+        spaId,
+        spaIP,
+        newWaterCareModeIdx,
+        getParent(obj.id, 1)
+    ]);
+    console.log('*** executing: ' + watercareModeCommand);
 
-    // signal that there is no longer a script is running
-    setState(dpBasePath + '.scriptRunning', {val: false, ack: true});
+    try {
+        await execPythonAsync(watercareModeCommand);
+    } finally {
+        // signal that there is no longer a script is running
+        setState(dpBasePath + '.scriptRunning', {val: false, ack: true});
+    }
     console.log("end");
 }

--- a/JavaScript/global/SpaGlobal.js
+++ b/JavaScript/global/SpaGlobal.js
@@ -19,10 +19,17 @@ function execPythonAsync(command) {
 }
 
 function buildShellCommand(parts) {
-    return parts
-        .filter((part) => part !== undefined && part !== null)
-        .map((part) => {
-            const value = String(part);
+    const filteredParts = parts.filter((part) => part !== undefined && part !== null);
+    if (filteredParts.length === 0) {
+        return "";
+    }
+
+    const commandParts = String(filteredParts[0]).trim().split(/\s+/).filter((part) => part !== "");
+    const argumentParts = filteredParts.slice(1).map((part) => String(part));
+
+    return commandParts
+        .concat(argumentParts)
+        .map((value) => {
             if (value === "") {
                 return "''";
             }
@@ -30,6 +37,7 @@ function buildShellCommand(parts) {
         })
         .join(" ");
 }
+
 
 function Sleep(milliseconds) {
     return new Promise(resolve => setTimeout(resolve, milliseconds));

--- a/JavaScript/global/SpaGlobal.js
+++ b/JavaScript/global/SpaGlobal.js
@@ -10,10 +10,25 @@ function execPythonAsync(command) {
             //console.log('*** stdout: ' + stdout);
             if (error) {
                 console.error('*** command failed with error code: ' + error.code + " - " + error.message);
+                reject(error);
+                return;
             }
             resolve();
         });
     })
+}
+
+function buildShellCommand(parts) {
+    return parts
+        .filter((part) => part !== undefined && part !== null)
+        .map((part) => {
+            const value = String(part);
+            if (value === "") {
+                return "''";
+            }
+            return "'" + value.replace(/'/g, "'\\''") + "'";
+        })
+        .join(" ");
 }
 
 function Sleep(milliseconds) {


### PR DESCRIPTION
### Motivation
- Ensure Python invocations are built safely with proper quoting/escaping and to avoid malformed command lines or injection issues.
- Always clear the `scriptRunning` datapoint even if the Python execution fails so the adapter does not get stuck waiting for a timeslot.

### Description
- Added `buildShellCommand(parts)` helper in `JavaScript/global/SpaGlobal.js` to quote and escape command parts and used it to construct all Python command lines.  
- Made `execPythonAsync` reject the promise when the executed command errors so callers can react to failures.  
- Updated all call sites (`LightToggle.js`, `PumpSwitches.js`, `SpaUpdateConfig.js`, `SpaUpdateValues.js`, `TargetTemp.js`, `WatercareMode.js`) to use `buildShellCommand`, log the built command, and wrap `execPythonAsync` calls in `try/finally` so `setState(dpBasePath + '.scriptRunning', {val: false, ack: true})` is always executed.  
- Refactored `SpaUpdateConfig.js` discovery/update flows to use the new command builder for per-controller and broadcast discovery invocations.

### Testing
- Ran static checks with `eslint` (or equivalent lint) on the modified files and no lint errors were reported.  
- Executed the updated adapter scripts in a runtime smoke test to invoke the modified code paths and observed that `scriptRunning` is cleared after errors or success (no automated test suite available for deeper coverage).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af2f08b3c08328b393f0884db9e01a)